### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build Status](https://travis-ci.org/pipermerriam/ethereum-contract.png)](https://travis-ci.org/pipermerriam/ethereum-contract)
 [![Documentation Status](https://readthedocs.org/projects/ethereum-contract/badge/?version=latest)](https://readthedocs.org/projects/ethereum-contract/?badge=latest)
-[![PyPi version](https://pypip.in/v/ethereum-contract/badge.png)](https://pypi.python.org/pypi/ethereum-contract)
-[![PyPi downloads](https://pypip.in/d/ethereum-contract/badge.png)](https://pypi.python.org/pypi/ethereum-ipc-utils)
+[![PyPi version](https://img.shields.io/pypi/v/ethereum-contract.svg)](https://pypi.python.org/pypi/ethereum-contract)
+[![PyPi downloads](https://img.shields.io/pypi/dm/ethereum-contract.svg)](https://pypi.python.org/pypi/ethereum-ipc-utils)
    
 
 A python object for interacting with Ethereum contracts.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20ethereum-contract))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `ethereum-contract`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.